### PR TITLE
fix: audit log reason not logging right info for duty command

### DIFF
--- a/src/commands/slash/duty.js
+++ b/src/commands/slash/duty.js
@@ -15,10 +15,10 @@ module.exports = {
 module.exports.run = ({ guild, member: author, respond }, { user = author.id }) => {
   const member = guild.members.cache.get(user), role = guild.roles.cache.get(roles.staffonduty);
   if (member.roles.cache.find(r => r.id == role.id)) {
-    member.roles.remove(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
+    member.roles.remove(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled by ${author.user.tag} (${author.user.id})`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You no longer have" : `${member.user.tag} no longer has`} the duty role.`);
   } else {
-    member.roles.add(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
+    member.roles.add(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled by ${author.user.tag} (${author.user.id})`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You now have" : `${member.user.tag} now has`} the duty role.`);
   }
 };

--- a/src/commands/slash/duty.js
+++ b/src/commands/slash/duty.js
@@ -15,10 +15,10 @@ module.exports = {
 module.exports.run = ({ guild, member: author, respond }, { user = author.id }) => {
   const member = guild.members.cache.get(user), role = guild.roles.cache.get(roles.staffonduty);
   if (member.roles.cache.find(r => r.id == role.id)) {
-    member.roles.remove(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled by ${author.user.tag} (${author.user.id})`);
+    member.roles.remove(role, user == author.id ? "User toggled" : `${author.user.tag} (${author.user.id}) toggled`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You no longer have" : `${member.user.tag} no longer has`} the duty role.`);
   } else {
-    member.roles.add(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled by ${author.user.tag} (${author.user.id})`);
+    member.roles.add(role, user == author.id ? "User toggled" : `${author.user.tag} (${author.user.id}) toggled`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You now have" : `${member.user.tag} now has`} the duty role.`);
   }
 };

--- a/src/commands/slash/duty.js
+++ b/src/commands/slash/duty.js
@@ -15,10 +15,10 @@ module.exports = {
 module.exports.run = ({ guild, member: author, respond }, { user = author.id }) => {
   const member = guild.members.cache.get(user), role = guild.roles.cache.get(roles.staffonduty);
   if (member.roles.cache.find(r => r.id == role.id)) {
-    member.roles.remove(role, user == member ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
+    member.roles.remove(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You no longer have" : `${member.user.tag} no longer has`} the duty role.`);
   } else {
-    member.roles.add(role, user == member ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
+    member.roles.add(role, member.id == author.id ? "User toggled" : `${member.user.tag} (${member.user.id}) toggled`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You now have" : `${member.user.tag} now has`} the duty role.`);
   }
-}; 
+};


### PR DESCRIPTION
With the check that is present at the moment, you are checking the member that you want the role to be added to (or yourself if no argument is given) with the userid of the member you want to add the role too (or yourself if no argument is given) which is always true. This fixes that problem so it correctly logs the correct audit log reason.