### PR TITLE
fix: possible strip command fix

### DIFF
--- a/src/commands/slash/strip.js
+++ b/src/commands/slash/strip.js
@@ -16,7 +16,7 @@ module.exports.run = async ({ client, guild, member: author, respond }, { user =
   const strip = await strips.get(user), member = guild.members.cache.get(user), executor = guild.members.cache.get(author);
   if (strip) {
     strips.unset(user);
-    member.roles.add(strip, user == author.id ? "User unstripped" : `${author.user.tag} (${author.user.id}) stripped`);
+    member.roles.add(strip, user == author.id ? "User unstripped" : `${author.user.tag} (${author.user.id}) unstripped`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} no longer stripped.`, true);
   } else if (getPermissionLevel({ id: executor.id, client }) < 1) return respond(`You cannot strip.`, true);
   else if (getPermissionLevel({ id: member.id, client }) >= 1) {

--- a/src/commands/slash/strip.js
+++ b/src/commands/slash/strip.js
@@ -16,7 +16,7 @@ module.exports.run = async ({ client, guild, member: author, respond }, { user =
   const strip = await strips.get(user), member = guild.members.cache.get(user), executor = guild.members.cache.get(author);
   if (strip) {
     strips.unset(user);
-    member.roles.add(strip, member.id == author.id ? "User unstripped" : `${executor.user.tag} (${executor.user.id}) unstripped by ${author.user.tag} (${author.user.id})`);
+    member.roles.add(strip, user == author.id ? "User unstripped" : `${author.user.tag} (${author.user.id}) stripped`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} no longer stripped.`, true);
   } else if (getPermissionLevel({ id: executor.id, client }) < 1) return respond(`You cannot strip.`, true);
   else if (getPermissionLevel({ id: member.id, client }) >= 1) {
@@ -27,7 +27,7 @@ module.exports.run = async ({ client, guild, member: author, respond }, { user =
       guild.me.roles.highest.position > r.position
     ).map(r => r.id);
     strips.set(user, roles);
-    member.roles.remove(roles, member.id == author.id ? "User stripped" : `${executor.user.tag} (${executor.user.id}) stripped by ${author.user.tag} (${author.user.id})`);
+    member.roles.remove(roles, user == author.id ? "User stripped" : `${author.user.tag} (${author.user.id}) stripped`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} now stripped.`, true);
   } else return respond(`${emojis.tickno} This person cannot strip.`, true);
 };

--- a/src/commands/slash/strip.js
+++ b/src/commands/slash/strip.js
@@ -13,12 +13,12 @@ module.exports = {
 };
 
 module.exports.run = async ({ client, guild, member: author, respond }, { user = author.id }) => {
-  const strip = await strips.get(user), member = guild.members.cache.get(user), executor = guild.members.cache.get(author);
+  const strip = await strips.get(user), member = guild.members.cache.get(user);
   if (strip) {
     strips.unset(user);
     member.roles.add(strip, user == author.id ? "User unstripped" : `${author.user.tag} (${author.user.id}) unstripped`);
     return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} no longer stripped.`, true);
-  } else if (getPermissionLevel({ id: executor.id, client }) < 1) return respond(`You cannot strip.`, true);
+  } else if (getPermissionLevel({ id: author.id, client }) < 1) return respond(`You cannot strip.`, true);
   else if (getPermissionLevel({ id: member.id, client }) >= 1) {
     const roles = member.roles.cache.filter(r =>
       r.id !== serverRoles.muted &&

--- a/src/commands/slash/strip.js
+++ b/src/commands/slash/strip.js
@@ -16,18 +16,18 @@ module.exports.run = async ({ client, guild, member: author, respond }, { user =
   const strip = await strips.get(user), member = guild.members.cache.get(user), executor = guild.members.cache.get(author);
   if (strip) {
     strips.unset(user);
-    member.roles.add(strip, user == member ? "User unstripped" : `${executor.user.tag} (${executor.user.id}) unstripped`);
-    return respond(`${emojis.tickyes} ${ member.id == author.id ? "You are" : `${member.user.tag} is`} no longer stripped.`, true);
+    member.roles.add(strip, member.id == author.id ? "User unstripped" : `${executor.user.tag} (${executor.user.id}) unstripped by ${author.user.tag} (${author.user.id})`);
+    return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} no longer stripped.`, true);
   } else if (getPermissionLevel({ id: executor.id, client }) < 1) return respond(`You cannot strip.`, true);
   else if (getPermissionLevel({ id: member.id, client }) >= 1) {
-    const roles = member.roles.cache.filter(r => 
+    const roles = member.roles.cache.filter(r =>
       r.id !== serverRoles.muted &&
       r.id !== guild.roles.everyone.id &&
       !r.managed &&
       guild.me.roles.highest.position > r.position
     ).map(r => r.id);
     strips.set(user, roles);
-    member.roles.remove(roles, member.id == author.id ? "User stripped" : `${executor.user.tag} (${executor.user.id}) stripped`);
-    return respond(`${emojis.tickyes} ${ member.id == author.id ? "You are" : `${member.user.tag} is`} now stripped.`, true);
+    member.roles.remove(roles, member.id == author.id ? "User stripped" : `${executor.user.tag} (${executor.user.id}) stripped by ${author.user.tag} (${author.user.id})`);
+    return respond(`${emojis.tickyes} ${member.id == author.id ? "You are" : `${member.user.tag} is`} now stripped.`, true);
   } else return respond(`${emojis.tickno} This person cannot strip.`, true);
 };


### PR DESCRIPTION
With the check that is present at the moment, you are checking the member that you want the role to be added to (or yourself if no argument is given) with the userid of the member you want to add the role too (or yourself if no argument is given) which is always true. This fixes that problem so it correctly logs the correct audit log reason. Also added some more information to the message.